### PR TITLE
Update dotfiles and readme

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,13 +15,5 @@
   "undef": true,
   "unused": true,
   "node": true,
-  "mocha": true,
-  "globals": {
-    "describe": false,
-    "it": false,
-    "before": false,
-    "beforeEach": false,
-    "after": false,
-    "afterEach": false
-  }
+  "mocha": true
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.DS_Store
-*.log
-node_modules
-build
-*.node
-*.orig
-.idea
-sandbox
-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vinyl-fs [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Dependency Status](https://david-dm.org/wearefractal/vinyl.png?theme=shields.io)](https://david-dm.org/wearefractal/vinyl-fs)
+# vinyl-fs [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Dependency Status][depstat-image]][depstat-url]
 
 ## Information
 
@@ -110,11 +110,11 @@ This is just [glob-watcher]
 [glob-watcher]: https://github.com/wearefractal/glob-watcher
 [vinyl]: https://github.com/wearefractal/vinyl
 
-[npm-url]: https://npmjs.org/package/vinyl-fs
-[npm-image]: https://badge.fury.io/js/vinyl-fs.png
+[npm-url]: https://www.npmjs.com/package/vinyl-fs
+[npm-image]: https://badge.fury.io/js/vinyl-fs.svg
 [travis-url]: https://travis-ci.org/wearefractal/vinyl-fs
-[travis-image]: https://travis-ci.org/wearefractal/vinyl-fs.png?branch=master
+[travis-image]: https://travis-ci.org/wearefractal/vinyl-fs.svg?branch=master
 [coveralls-url]: https://coveralls.io/r/wearefractal/vinyl-fs
-[coveralls-image]: https://coveralls.io/repos/wearefractal/vinyl-fs/badge.png
+[coveralls-image]: https://img.shields.io/coveralls/wearefractal/vinyl-fs.svg?style=flat
 [depstat-url]: https://david-dm.org/wearefractal/vinyl-fs
-[depstat-image]: https://david-dm.org/wearefractal/vinyl-fs.png
+[depstat-image]: https://david-dm.org/wearefractal/vinyl-fs.svg

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "buffer-equal": "^0.0.1",
     "coveralls": "^2.6.1",
     "istanbul": "^0.3.0",
+    "istanbul-coveralls": "^1.0.1",
     "jshint": "^2.4.1",
     "mocha": "^2.0.0",
     "mocha-lcov-reporter": "^0.0.1",
@@ -32,8 +33,8 @@
     "sinon": "^1.10.3"
   },
   "scripts": {
-    "test": "mocha --reporter spec && jshint lib",
-    "coveralls": "istanbul cover _mocha -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "test": "jshint lib && mocha",
+    "coveralls": "istanbul cover _mocha && istanbul-coveralls"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
* I removed `globals` from [.jshintrc](https://github.com/wearefractal/vinyl-fs/blob/master/.jshintrc). It's unnecessary because `mocha` option is enabled.
* I removed .npmignore file. It's unnecessary because package.json has `main` field.
* I added `sudo: false` to [.travis.yml](https://github.com/wearefractal/vinyl-fs/blob/master/.travis.yml) to use [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) on Travis CI.
* I updated image format of the badges in readme from PNG to SVG. SVG badges look beautiful on retina display.
* I introduced [istanbul-coveralls](https://github.com/shinnn/istanbul-coveralls).
