### PR TITLE
Implemented `overwrite` option in `dest()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This is just [glob-watcher]
   - cwd - Specify the working directory the folder is relative to. Default is `process.cwd()`
   - mode - Specify the mode the files should be created with. Default is the mode of the input file (file.stat.mode) or the process mode if the input file has no mode property.
   - dirMode - Specify the mode the directory should be created with. Default is the process mode.
+  - overwrite - Specify if existing files with the same path should be overwritten or not. Default is `true`, to always overwrite existing files
 - Returns a Readable/Writable stream.
 - On write the stream will save the [vinyl] File to disk at the folder/cwd specified.
 - After writing the file to disk, it will be emitted from the stream so you can keep piping these around.

--- a/lib/dest/writeContents/index.js
+++ b/lib/dest/writeContents/index.js
@@ -31,7 +31,9 @@ function writeContents(writePath, file, cb) {
   }
 
   function written(err) {
-    if (err) {
+    var ignorableError = (err && err.code === 'EEXIST' && file.flag === 'wx');
+
+    if (err && !ignorableError) {
       return complete(err);
     }
 

--- a/lib/dest/writeContents/index.js
+++ b/lib/dest/writeContents/index.js
@@ -31,9 +31,8 @@ function writeContents(writePath, file, cb) {
   }
 
   function written(err) {
-    var ignorableError = (err && err.code === 'EEXIST' && file.flag === 'wx');
 
-    if (err && !ignorableError) {
+    if (isErrorFatal(err)) {
       return complete(err);
     }
 
@@ -52,6 +51,20 @@ function writeContents(writePath, file, cb) {
       }
       fs.chmod(writePath, file.stat.mode, complete);
     });
+  }
+
+  function isErrorFatal(err) {
+    if (!err) {
+      return false;
+    }
+
+    // Handle scenario for file overwrite failures.
+    else if (err.code === 'EEXIST' && file.flag === 'wx') {
+      return false;   // "These aren't the droids you're looking for"
+    }
+
+    // Otherwise, this is a fatal error
+    return true;
   }
 }
 

--- a/lib/dest/writeContents/writeBuffer.js
+++ b/lib/dest/writeContents/writeBuffer.js
@@ -4,7 +4,8 @@ var fs = require('graceful-fs');
 
 function writeBuffer(writePath, file, cb) {
   var opt = {
-    mode: file.stat.mode
+    mode: file.stat.mode,
+    flag: file.flag
   };
 
   fs.writeFile(writePath, file.contents, opt, cb);

--- a/lib/dest/writeContents/writeStream.js
+++ b/lib/dest/writeContents/writeStream.js
@@ -5,7 +5,8 @@ var fs = require('graceful-fs');
 
 function writeStream(writePath, file, cb) {
   var opt = {
-    mode: file.stat.mode
+    mode: file.stat.mode,
+    flag: file.flag
   };
 
   var outStream = fs.createWriteStream(writePath, opt);

--- a/lib/prepareWrite.js
+++ b/lib/prepareWrite.js
@@ -30,6 +30,7 @@ function prepareWrite(outFolder, file, opt, cb) {
   // wire up new properties
   file.stat = (file.stat || new fs.Stats());
   file.stat.mode = options.mode;
+  file.flag = options.flag;
   file.cwd = cwd;
   file.base = basePath;
   file.path = writePath;


### PR DESCRIPTION
This is in reference to: https://github.com/wearefractal/vinyl-fs/issues/30

It seemed like the overwrite option was stubbed out, but the `wx` flag was never utilized in the fs operations. This commit wires it up, handles the error catch scenario and adds some tests. Let me know what you think!
