### PR TITLE
Compare modes on comparable bases

### DIFF
--- a/lib/dest/writeContents/index.js
+++ b/lib/dest/writeContents/index.js
@@ -44,9 +44,7 @@ function writeContents(writePath, file, cb) {
       if (err) {
         return complete(err);
       }
-      // octal 7777 = decimal 4095
-      var currentMode = (st.mode & 4095);
-      if (currentMode === file.stat.mode) {
+      if (st.mode === file.stat.mode) {
         return complete();
       }
       fs.chmod(writePath, file.stat.mode, complete);


### PR DESCRIPTION
Converting only the source mode will yield a diiference that results in always trying to chmod the destination, which may be forbidden in some cases (in my case the conversion resulted in a missing flag which I wasn't allowed to remove).