### PR TITLE
Fix mode comparison

### DIFF
--- a/lib/dest/writeContents/index.js
+++ b/lib/dest/writeContents/index.js
@@ -44,12 +44,12 @@ function writeContents(writePath, file, cb) {
       if (err) {
         return complete(err);
       }
-      // octal 7777 = decimal 4095
-      var currentMode = (st.mode & 4095);
-      if (currentMode === file.stat.mode) {
+      var currentMode = (st.mode & parseInt('0777', 8));
+      var expectedMode = (file.stat.mode & parseInt('0777', 8));
+      if (currentMode === expectedMode) {
         return complete();
       }
-      fs.chmod(writePath, file.stat.mode, complete);
+      fs.chmod(writePath, expectedMode, complete);
     });
   }
 

--- a/test/dest.js
+++ b/test/dest.js
@@ -713,6 +713,56 @@ describe('dest stream', function() {
     stream.end();
   });
 
+  it('should see a file with special chmod (setuid/setgid/sticky) as matching', function(done) {
+    var inputPath = path.join(__dirname, './fixtures/test.coffee');
+    var inputBase = path.join(__dirname, './fixtures/');
+    var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
+    var expectedContents = fs.readFileSync(inputPath);
+    var expectedCwd = __dirname;
+    var expectedBase = path.join(__dirname, './out-fixtures');
+    var expectedMode = 03722;
+    var normalMode = 0722;
+
+    var expectedFile = new File({
+      base: inputBase,
+      cwd: __dirname,
+      path: inputPath,
+      contents: expectedContents,
+      stat: {
+        mode: normalMode
+      }
+    });
+
+    var expectedCount = 0;
+    spies.setError(function(mod, fn) {
+      if (fn === 'stat' && arguments[2] === expectedPath) {
+        expectedCount++;
+      }
+    });
+
+    var onEnd = function(){
+      expectedCount.should.equal(1);
+      should(chmodSpy.called).be.not.ok;
+      realMode(fs.lstatSync(expectedPath).mode).should.equal(expectedMode);
+      done();
+    };
+
+    fs.mkdirSync(expectedBase);
+    fs.closeSync(fs.openSync(expectedPath, 'w'));
+    fs.chmodSync(expectedPath, expectedMode);
+
+    statSpy.reset();
+    chmodSpy.reset();
+    var stream = vfs.dest('./out-fixtures/', {cwd: __dirname});
+
+    var buffered = [];
+    bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+
+    stream.pipe(bufferStream);
+    stream.write(expectedFile);
+    stream.end();
+  });
+
   it('should not overwrite files with overwrite option set to false', function(done) {
     var inputPath = path.join(__dirname, './fixtures/test.coffee');
     var inputBase = path.join(__dirname, './fixtures/');


### PR DESCRIPTION
Related to #61, I found that the actual issue is currentMode gets its flags stripped by the bitwise comparison, but not the destination mode. This adds bitwise comparison to the dest mode to fix detection of different modes.