### PR TITLE
switch to glob-watcher 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "duplexify": "^3.2.0",
     "glob-stream": "^4.0.1",
-    "glob-watcher": "^0.0.8",
+    "glob-watcher": "^2.0.0",
     "graceful-fs": "^3.0.0",
     "merge-stream": "^0.1.7",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
this relies on the recent breaking changes to glob-watcher being published to npm as 2.0

@contra this will cause vinyl-fs to require a 2.0 bump also.