### PR TITLE
Remove realMode equality test on special bit test

### DIFF
--- a/test/dest.js
+++ b/test/dest.js
@@ -743,7 +743,6 @@ describe('dest stream', function() {
     var onEnd = function(){
       expectedCount.should.equal(1);
       should(chmodSpy.called).be.not.ok;
-      realMode(fs.lstatSync(expectedPath).mode).should.equal(expectedMode);
       done();
     };
 


### PR DESCRIPTION
It has been shown in #62 this bit can be platform specific and is unreliable, testing fs.chmod is not called will be enough.