### PR TITLE
using is-valid-glob module to handle nested arrays properly

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -8,6 +8,7 @@ var duplexify = require('duplexify');
 var merge = require('merge-stream');
 var sourcemaps = require('gulp-sourcemaps');
 var filterSince = require('vinyl-filter-since');
+var isValidGlob = require('is-valid-glob');
 
 var getContents = require('./getContents');
 var resolveSymlinks = require('./resolveSymlinks');
@@ -64,19 +65,6 @@ function src(glob, opt) {
   }
   globStream.on('error', outputStream.emit.bind(outputStream, 'error'));
   return outputStream;
-}
-
-function isValidGlob(glob) {
-  if (typeof glob === 'string') {
-    return true;
-  }
-  if (!Array.isArray(glob)) {
-    return false;
-  }
-  if (glob.length !== 0) {
-    return glob.every(isValidGlob);
-  }
-  return true;
 }
 
 module.exports = src;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "glob-watcher": "^2.0.0",
     "graceful-fs": "^3.0.0",
     "gulp-sourcemaps": "^1.5.2",
+    "is-valid-glob": "^0.1.0",
     "merge-stream": "^0.1.7",
     "mkdirp": "^0.5.0",
     "object-assign": "^2.0.0",

--- a/test/src.js
+++ b/test/src.js
@@ -41,6 +41,18 @@ describe('source stream', function() {
     }
   });
 
+  it('should explode on invalid glob (nested array)', function(done) {
+    var stream;
+    try {
+      stream = vfs.src([['./fixtures/*.coffee']]);
+    } catch (err) {
+      should.exist(err);
+      should.not.exist(stream);
+      err.message.should.containEql('Invalid glob argument');
+      done();
+    }
+  });
+
   it('should not explode on invalid glob (empty array)', function(done) {
     var stream = vfs.src([]);
     stream.once('data', done);


### PR DESCRIPTION
If a nested array: `[ ['./fixtures/*.coffee'] ]` is passed, the current `isValidGlob` method will return `true` and `glob-stream` will end up throwing an 'Invalid glob at index 0` error.

Using `is-valid-glob` handles this case and causes `src` to throw an `Invalid glob argument: ` error instead.

Added test to validate.